### PR TITLE
Remove unused HistoryResource.Permissions

### DIFF
--- a/mreg_api/models/history.py
+++ b/mreg_api/models/history.py
@@ -28,7 +28,6 @@ class HistoryResource(str, Enum):
     """
 
     Host = "hosts"
-    Permissions = "permissions"
     Group = "groups"
     HostPolicy_Role = "roles"
     HostPolicy_Atom = "atoms"


### PR DESCRIPTION
History for permissions is not logged in Mreg, so this enum value has no reason to exist.