### PR TITLE
Remove **kwargs from CRUD methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `MregClient(user_agent=)` parameter for setting a custom user agent.
 
+### Changed
+
+- **Breaking:** `MregClient.{get,post,patch,delete}()`:
+  - All arguments apart from `path` are now keyword-only.
+  - Replace parameter `**kwargs` with an explicit `json: Json | None = None` parameter.
+- **Breaking:** `APIMixin.patch()`:
+  - Renamed parameter `fields` to `data` (type changed from `Mapping[str, Any]` to `Json`)
+  - Added parameter `params: QueryParams | None = None`
+  - Made parameter `validate` keyword-only.
+- **Breaking:** `APIMixin.create()`:
+  - Renamed parameter `params` to `data` (type unchanged)
+  - Made parameter `fetch_after_create` keyword-only.
+- **Breaking:** `Community.patch()` (Mirrors `APIMixin.patch`):
+  - Renamed parameter `fields` to `data` (type changed from `Mapping[str, Any]` to `Json`)
+  - Added parameter `params: QueryParams | None = None`
+  - Made parameter `validate` keyword-only.
+
 ## [0.1.5](https://github.com/unioslo/mreg-api/releases/tag/0.1.5) - 2026-03-26
 
 ### Added

--- a/mreg_api/client.py
+++ b/mreg_api/client.py
@@ -153,7 +153,7 @@ class RequestRecord(NamedTuple):
     response: Response
     status: int
     data: JsonMapping | None
-    json: JsonMapping | None
+    json: Json | None
 
     @property
     def path(self) -> str:
@@ -488,7 +488,7 @@ class MregClient(metaclass=SingletonMeta):
         self,
         response: Response,
         data: JsonMapping | None = None,
-        json: JsonMapping | None = None,
+        json: Json | None = None,
     ) -> None:
         """Add a request/response pair to the history log."""
         self.history.append(
@@ -623,7 +623,8 @@ class MregClient(metaclass=SingletonMeta):
         path: str,
         params: QueryParams | None = None,
         ok404: bool = False,
-        **data: Any,
+        *,
+        json: Json | None = None,
     ) -> Response | None:
         """Make an HTTP request to the MREG API.
 
@@ -632,7 +633,7 @@ class MregClient(metaclass=SingletonMeta):
             path: API path (relative to base URL)
             params: Query parameters
             ok404: Whether to return None on 404 instead of raising
-            **data: Request body data
+            json: Request body data as a JSON-serializable value
 
         Returns:
             Response object or None if ok404=True and status is 404
@@ -657,15 +658,15 @@ class MregClient(metaclass=SingletonMeta):
         if method != "GET" and params:
             logger.debug("Params: %s", params)
 
-        if data:
-            logger.debug("Data: %s", data)
+        if json is not None:
+            logger.debug("Json: %s", json)
 
-        # Strip None values from data (except for PATCH)
-        if data and method != "PATCH":
-            data = self._strip_none(data)
+        # Strip None values from json body (except for PATCH)
+        if json is not None and method != "PATCH" and isinstance(json, Mapping):
+            json = self._strip_none(json) or None
 
         # Construct the request object
-        request = self.session.build_request(method=method, url=url, params=params, json=data or None)
+        request = self.session.build_request(method=method, url=url, params=params, json=json)
         logger.info("Request: %s %s [%s]", method, request.url, self.get_correlation_id())
 
         # Update context variables for error reporting
@@ -674,7 +675,7 @@ class MregClient(metaclass=SingletonMeta):
 
         result = self.session.send(request)
         # Log response in response log
-        self._add_to_history(result, json=data)
+        self._add_to_history(result, json=json)
 
         # # This is a workaround for old server versions that can't handle JSON data in requests
         # if result.is_redirect and not result.history and params == {} and data:
@@ -718,18 +719,22 @@ class MregClient(metaclass=SingletonMeta):
         return "?".join(parts)
 
     @overload
-    def get(self, path: str, params: QueryParams | None, ok404: Literal[True]) -> Response | None: ...
+    def get(
+        self, path: str, *, params: QueryParams | None = ..., ok404: Literal[True]
+    ) -> Response | None: ...
 
     @overload
-    def get(self, path: str, params: QueryParams | None, ok404: Literal[False]) -> Response: ...
+    def get(self, path: str, *, params: QueryParams | None = ..., ok404: Literal[False]) -> Response: ...
 
     @overload
-    def get(self, path: str, params: QueryParams | None = ..., *, ok404: bool) -> Response | None: ...
+    def get(self, path: str, *, params: QueryParams | None = ..., ok404: bool) -> Response | None: ...
 
     @overload
-    def get(self, path: str, params: QueryParams | None = ...) -> Response: ...
+    def get(self, path: str, *, params: QueryParams | None = None) -> Response: ...
 
-    def get(self, path: str, params: QueryParams | None = None, ok404: bool = False) -> Response | None:
+    def get(
+        self, path: str, *, params: QueryParams | None = None, ok404: bool = False
+    ) -> Response | None:
         """Make a standard get request."""
         if self.cache.is_enabled:
             cache_key = self._make_cache_key(path, params, ok404)
@@ -739,12 +744,14 @@ class MregClient(metaclass=SingletonMeta):
             except CacheMiss:
                 logger.debug("Cache miss for key: %s", cache_key)
 
-            ret = self._do_get(path, params, ok404)
+            ret = self._do_get(path, params=params, ok404=ok404)
             self.cache.set(cache_key, ret)
             return ret
-        return self._do_get(path, params, ok404)
+        return self._do_get(path, params=params, ok404=ok404)
 
-    def _do_get(self, path: str, params: QueryParams | None, ok404: bool = False) -> Response | None:
+    def _do_get(
+        self, path: str, *, params: QueryParams | None = None, ok404: bool = False
+    ) -> Response | None:
         try:
             return self.request("GET", path, params=params, ok404=ok404)
         except GetError as e:
@@ -754,33 +761,46 @@ class MregClient(metaclass=SingletonMeta):
 
     @overload
     def post(
-        self, path: str, params: QueryParams | None, ok404: Literal[True], **kwargs: Json
+        self,
+        path: str,
+        *,
+        json: Json | None = ...,
+        params: QueryParams | None = ...,
+        ok404: Literal[True],
     ) -> Response | None: ...
 
     @overload
     def post(
-        self, path: str, params: QueryParams | None, ok404: Literal[False], **kwargs: Json
+        self,
+        path: str,
+        *,
+        json: Json | None = ...,
+        params: QueryParams | None = ...,
+        ok404: Literal[False],
     ) -> Response: ...
 
     @overload
     def post(
-        self, path: str, params: QueryParams | None = ..., *, ok404: bool, **kwargs: Json
-    ) -> Response: ...
+        self, path: str, *, json: Json | None = ..., params: QueryParams | None = ..., ok404: bool
+    ) -> Response | None: ...
 
     @overload
-    def post(self, path: str, params: QueryParams | None = ..., **kwargs: Json) -> Response: ...
+    def post(
+        self, path: str, *, json: Json | None = None, params: QueryParams | None = None
+    ) -> Response: ...
 
     @invalidate_cache
     def post(
         self,
         path: str,
+        *,
+        json: Json | None = None,
         params: QueryParams | None = None,
         ok404: bool = False,
-        **kwargs: Json,
     ) -> Response | None:
         """Make a POST request."""
         try:
-            return self.request("POST", path, params, ok404=ok404, **kwargs)
+            return self.request("POST", path, params=params, ok404=ok404, json=json)
         except PostError as e:
             raise e
         except APIError as e:
@@ -788,33 +808,46 @@ class MregClient(metaclass=SingletonMeta):
 
     @overload
     def patch(
-        self, path: str, params: QueryParams | None, ok404: Literal[True], **kwargs: Json
+        self,
+        path: str,
+        *,
+        json: Json | None = ...,
+        params: QueryParams | None = ...,
+        ok404: Literal[True],
     ) -> Response | None: ...
 
     @overload
     def patch(
-        self, path: str, params: QueryParams | None, ok404: Literal[False], **kwargs: Json
+        self,
+        path: str,
+        *,
+        json: Json | None = ...,
+        params: QueryParams | None = ...,
+        ok404: Literal[False],
     ) -> Response: ...
 
     @overload
     def patch(
-        self, path: str, params: QueryParams | None = ..., *, ok404: bool, **kwargs: Json
-    ) -> Response: ...
+        self, path: str, *, json: Json | None = ..., params: QueryParams | None = ..., ok404: bool
+    ) -> Response | None: ...
 
     @overload
-    def patch(self, path: str, params: QueryParams | None = ..., **kwargs: Json) -> Response: ...
+    def patch(
+        self, path: str, *, json: Json | None = None, params: QueryParams | None = None
+    ) -> Response: ...
 
     @invalidate_cache
     def patch(
         self,
         path: str,
+        *,
+        json: Json | None = None,
         params: QueryParams | None = None,
         ok404: bool = False,
-        **kwargs: Json,
     ) -> Response | None:
         """Make a PATCH request."""
         try:
-            return self.request("PATCH", path, params, ok404=ok404, **kwargs)
+            return self.request("PATCH", path, params=params, ok404=ok404, json=json)
         except PatchError as e:
             raise e
         except APIError as e:
@@ -822,33 +855,46 @@ class MregClient(metaclass=SingletonMeta):
 
     @overload
     def delete(
-        self, path: str, params: QueryParams | None, ok404: Literal[True], **kwargs: Json
+        self,
+        path: str,
+        *,
+        json: Json | None = ...,
+        params: QueryParams | None = ...,
+        ok404: Literal[True],
     ) -> Response | None: ...
 
     @overload
     def delete(
-        self, path: str, params: QueryParams | None, ok404: Literal[False], **kwargs: Json
+        self,
+        path: str,
+        *,
+        json: Json | None = ...,
+        params: QueryParams | None = ...,
+        ok404: Literal[False],
     ) -> Response: ...
 
     @overload
     def delete(
-        self, path: str, params: QueryParams | None = ..., *, ok404: bool, **kwargs: Json
-    ) -> Response: ...
+        self, path: str, *, json: Json | None = ..., params: QueryParams | None = ..., ok404: bool
+    ) -> Response | None: ...
 
     @overload
-    def delete(self, path: str, params: QueryParams | None = ..., **kwargs: Json) -> Response: ...
+    def delete(
+        self, path: str, *, json: Json | None = None, params: QueryParams | None = None
+    ) -> Response: ...
 
     @invalidate_cache
     def delete(
         self,
         path: str,
+        *,
+        json: Json | None = None,
         params: QueryParams | None = None,
         ok404: bool = False,
-        **kwargs: Json,
     ) -> Response | None:
         """Make a DELETE request."""
         try:
-            return self.request("DELETE", path, params, ok404=ok404, **kwargs)
+            return self.request("DELETE", path, params=params, ok404=ok404, json=json)
         except DeleteError as e:
             raise e
         except APIError as e:
@@ -949,7 +995,7 @@ class MregClient(metaclass=SingletonMeta):
 
     def get_first(self, path: str) -> JsonMapping | None:
         """Get the first item from a list endpoint."""
-        response = self.get(path, {"page_size": 1})
+        response = self.get(path, params={"page_size": 1})
 
         # Non-paginated results, return them directly
         if "count" not in response.text:
@@ -1032,7 +1078,7 @@ class MregClient(metaclass=SingletonMeta):
         Returns:
             A list of dictionaries or a dictionary if expect_one_result is True.
         """
-        response = self.get(path, params)
+        response = self.get(path, params=params)
 
         # Non-paginated results, return them directly
         if "count" not in response.text:

--- a/mreg_api/models/abstracts.py
+++ b/mreg_api/models/abstracts.py
@@ -526,7 +526,9 @@ class APIMixin(ABC):
             raise GetError(f"Could not refresh {self.__class__.__name__} with ID {identifier}.")
         return obj
 
-    def patch(self, fields: Mapping[str, Any], validate: bool = False) -> Self:
+    def patch(
+        self, data: JsonMapping, *, params: QueryParams | None = None, validate: bool = False
+    ) -> Self:
         """Patch the object with the given values.
 
         Note:
@@ -535,7 +537,8 @@ class APIMixin(ABC):
                are). Odds are you want to pass an empty string instead.
 
         Args:
-            fields: The values to patch.
+            data: The values to patch.
+            params: Optional query parameters.
             validate: Whether to validate the patched object.
 
         Returns:
@@ -543,13 +546,13 @@ class APIMixin(ABC):
         """
         from mreg_api.client import MregClient  # noqa: PLC0415
 
-        MregClient().patch(self.endpoint().with_id(self.id_for_endpoint()), **fields)
+        MregClient().patch(self.endpoint().with_id(self.id_for_endpoint()), json=data, params=params)
         new_object = self.refetch()
 
         if validate:
             # __init_subclass__ guarantees we inherit from BaseModel
             # but we can't signal this to the type checker, so we cast here.
-            validate_patched_model(cast(BaseModel, new_object), fields)  # pyright: ignore[reportInvalidCast] # we know what we are doing here (...?!)
+            validate_patched_model(cast(BaseModel, new_object), data)  # pyright: ignore[reportInvalidCast] # we know what we are doing here (...?!)
 
         return new_object
 
@@ -569,7 +572,7 @@ class APIMixin(ABC):
         return False
 
     @classmethod
-    def create(cls, params: JsonMapping, fetch_after_create: bool = True) -> Self | None:
+    def create(cls, data: JsonMapping, *, fetch_after_create: bool = True) -> Self | None:
         """Create the object.
 
         Note that several endpoints do not support location headers for created objects,
@@ -577,7 +580,7 @@ class APIMixin(ABC):
         if the object was created successfully...
 
         Args:
-            params: The parameters to create the object with.
+            data: The data to create the object with.
             fetch_after_create: Whether to fetch the object after creation.
 
         Raises:
@@ -591,7 +594,7 @@ class APIMixin(ABC):
 
         client = MregClient()
 
-        response = client.post(cls.endpoint(), params=None, ok404=False, **params)
+        response = client.post(cls.endpoint(), json=data)
 
         if response and response.is_success:
             # NOTE: Headers.__getitem__ returns a str, while
@@ -607,6 +610,6 @@ class APIMixin(ABC):
             # raise APIError("No location header in response.")
 
         else:
-            raise PostError(f"Failed to create {cls} with {params} @ {cls.endpoint()}.")
+            raise PostError(f"Failed to create {cls} with {data} @ {cls.endpoint()}.")
 
         return None

--- a/mreg_api/models/models.py
+++ b/mreg_api/models/models.py
@@ -6,7 +6,6 @@ import ipaddress
 import logging
 import warnings
 from abc import ABC
-from collections.abc import Mapping
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
@@ -66,6 +65,8 @@ from mreg_api.models.history import HistoryItem
 from mreg_api.models.history import HistoryResource
 from mreg_api.types import IP_AddressT
 from mreg_api.types import IP_NetworkT
+from mreg_api.types import Json
+from mreg_api.types import JsonMapping
 from mreg_api.types import QueryParams
 from mreg_api.types import get_type_adapter
 from mreg_api.utilities.shared import convert_wildcard_to_regex
@@ -811,7 +812,7 @@ class Zone(FrozenModelWithTimestamps, WithTTL, APIMixin):
             expire: The expire interval for the zone.
             soa_ttl: The TTL for the zone.
         """
-        params: QueryParams = {
+        data: JsonMapping = {
             "primary_ns": primary_ns,
             "email": email,
             "serialno": serialno,
@@ -820,10 +821,10 @@ class Zone(FrozenModelWithTimestamps, WithTTL, APIMixin):
             "expire": expire,
             "soa_ttl": self.valid_numeric_ttl(soa_ttl) if soa_ttl is not None else None,
         }
-        params = {k: v for k, v in params.items() if v is not None}
-        if not params:
-            raise InputFailure("No parameters to update")
-        return self.patch(params)
+        data = {k: v for k, v in data.items() if v is not None}
+        if not data:
+            raise InputFailure("No fields to update")
+        return self.patch(data)
 
     def create_delegation(
         self,
@@ -864,9 +865,7 @@ class Zone(FrozenModelWithTimestamps, WithTTL, APIMixin):
         try:
             MregClient().post(
                 cls.endpoint().with_params(self.name),
-                name=delegation,
-                nameservers=nameservers,
-                comment=comment,
+                json={"name": delegation, "nameservers": nameservers, "comment": comment},
             )
         except PostError as e:
             # TODO: implement after mreg-cli parity
@@ -966,7 +965,9 @@ class Zone(FrozenModelWithTimestamps, WithTTL, APIMixin):
 
         delegation = self.get_delegation_or_raise(name)
         try:
-            MregClient().patch(delegation.endpoint_with_id(self, delegation.name), comment=comment)
+            MregClient().patch(
+                delegation.endpoint_with_id(self, delegation.name), json={"comment": comment}
+            )
         except PatchError as e:
             # TODO: implement after mreg-cli parity
             # raise PatchError(
@@ -997,7 +998,7 @@ class Zone(FrozenModelWithTimestamps, WithTTL, APIMixin):
         self.verify_nameservers(nameservers, force=force)
         path = self.endpoint_nameservers().with_params(self.name)
         try:
-            MregClient().patch(path, primary_ns=nameservers)
+            MregClient().patch(path, json={"primary_ns": nameservers})
         except PatchError as e:
             # TODO: implement after mreg-cli parity
             # raise PatchError(
@@ -1358,7 +1359,9 @@ class Role(HostPolicy, WithHistory):
             if atom_name == atom:
                 raise EntityAlreadyExists(f"Atom {atom!r} already a member of role {self.name!r}")
 
-        resp = MregClient().post(Endpoint.HostPolicyRolesAddAtom.with_params(self.name), name=atom_name)
+        resp = MregClient().post(
+            Endpoint.HostPolicyRolesAddAtom.with_params(self.name), json={"name": atom_name}
+        )
         return resp.is_success if resp else False
 
     def remove_atom(self, atom_name: str) -> bool:
@@ -1430,7 +1433,9 @@ class Role(HostPolicy, WithHistory):
         """
         from mreg_api.client import MregClient  # noqa: PLC0415
 
-        resp = MregClient().post(Endpoint.HostPolicyRolesAddHost.with_params(self.name), name=name)
+        resp = MregClient().post(
+            Endpoint.HostPolicyRolesAddHost.with_params(self.name), json={"name": name}
+        )
         return resp.is_success if resp else False
 
     def remove_host(self, name: str) -> bool:
@@ -1763,8 +1768,7 @@ class Network(FrozenModelWithTimestamps, APIMixin):
 
         resp = MregClient().post(
             Endpoint.NetworkCommunities.with_params(self.network),
-            name=name,
-            description=description,
+            json={"name": name, "description": description},
         )
         return resp.is_success if resp else False
 
@@ -1878,9 +1882,7 @@ class Network(FrozenModelWithTimestamps, APIMixin):
         try:
             MregClient().post(
                 Endpoint.NetworksAddExcludedRanges.with_params(self.network),
-                network=self.id,
-                start_ip=str(start_ip),
-                end_ip=str(end_ip),
+                json={"network": self.id, "start_ip": str(start_ip), "end_ip": str(end_ip)},
             )
         except PostError as e:
             # TODO: implement after mreg-cli parity
@@ -2086,11 +2088,19 @@ class Community(FrozenModelWithTimestamps, APIMixin):
 
         return MregClient().get_typed(self.endpoint_with_id, self.__class__)
 
-    def patch(self, fields: Mapping[str, Any], validate: bool = False) -> Self:  # noqa: ARG002 # validate not implemented
+    @override
+    def patch(
+        self,
+        data: JsonMapping,
+        *,
+        params: QueryParams | None = None,
+        validate: bool = False,  # noqa: ARG002, E501
+    ) -> Self:
         """Patch the community.
 
         Args:
-            fields: The fields to patch.
+            data: The data to patch.
+            params: Optional query parameters.
             validate: Whether to validate the response. (Not implemented)
 
         Returns:
@@ -2099,7 +2109,7 @@ class Community(FrozenModelWithTimestamps, APIMixin):
         from mreg_api.client import MregClient  # noqa: PLC0415
 
         try:
-            MregClient().patch(self.endpoint_with_id, **fields)
+            MregClient().patch(self.endpoint_with_id, json=data, params=params)
         except PatchError as e:
             # TODO: implement after mreg-cli parity
             # raise PatchError(f"Failed to patch community {self.name!r}", e.response) from e
@@ -2136,10 +2146,10 @@ class Community(FrozenModelWithTimestamps, APIMixin):
         """
         from mreg_api.client import MregClient  # noqa: PLC0415
 
-        kwargs: QueryParams = {"id": host.id}
+        data: dict[str, Json] = {"id": host.id}
         if ipaddress:
-            kwargs["ipaddress"] = str(ipaddress)
-        resp = MregClient().post(self.hosts_endpoint, params=None, ok404=False, **kwargs)
+            data["ipaddress"] = str(ipaddress)
+        resp = MregClient().post(self.hosts_endpoint, json=data)
         return resp.is_success if resp else False
 
     def remove_host(self, host: Host, ipaddress: IP_AddressT | None = None) -> bool:
@@ -2162,7 +2172,7 @@ class Community(FrozenModelWithTimestamps, APIMixin):
                 self.network_address,
                 self.id,
                 host.id,
-            )
+            ),
         )
         return resp.is_success if resp else False
 
@@ -2300,8 +2310,7 @@ class NetworkPolicy(FrozenModelWithTimestamps, WithName):
 
         resp = client.post(
             Endpoint.NetworkCommunities.with_params(self.id),
-            name=name,
-            description=description,
+            json={"name": name, "description": description},
         )
         if resp and (location := resp.headers.get("Location")):
             return client.get_typed(location, Community)
@@ -2448,7 +2457,7 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
             raise EntityAlreadyExists(
                 f"IP address {self.ipaddress} already has MAC address {self.macaddress}."
             )
-        return self.patch(fields={"macaddress": mac})
+        return self.patch(data={"macaddress": mac})
 
     def disassociate_mac(self) -> IPAddress:
         """Disassociate the MAC address from the IP address.
@@ -2459,7 +2468,7 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
             A new IPAddress object fetched from the API with the MAC address removed.
         """
         # Model converts empty string to None so we must validate this ourselves.
-        patched = self.patch(fields={"macaddress": ""}, validate=False)
+        patched = self.patch(data={"macaddress": ""}, validate=False)
         if patched.macaddress:
             raise PatchError(f"Failed to disassociate MAC address from {self.ipaddress}")
         return patched
@@ -3234,7 +3243,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         Returns:
             A new Host object fetched from the API with the updated name.
         """
-        return self.patch(fields={"name": new_name})
+        return self.patch(data={"name": new_name})
 
     def set_comment(self, comment: str) -> Host:
         """Set the comment for the host.
@@ -3245,7 +3254,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         Returns:
             A new Host object fetched from the API with the updated comment.
         """
-        return self.patch(fields={"comment": comment})
+        return self.patch(data={"comment": comment})
 
     @deprecated("Use set_contacts instead")
     def set_contact(self, contact: str) -> Host:
@@ -3261,7 +3270,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         Returns:
             A new Host object fetched from the API with the updated contact.
         """
-        return self.patch(fields={"contact": contact})
+        return self.patch(data={"contact": contact})
 
     def set_contacts(self, contacts: list[str]) -> Host:
         """Set a new list of contacts for the host. Overwrites existing contacts.
@@ -3273,7 +3282,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
             Host: Updated Host object.
         """
         # Uses non-atomic host update via PATCH to set the contacts list.
-        return self.patch(fields={"contacts": contacts}, validate=False)
+        return self.patch(data={"contacts": contacts}, validate=False)
 
     def add_contacts(self, contacts: list[str]) -> HostContactModification:
         """Add contacts to the host.
@@ -3292,7 +3301,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         # Uses atomic endpoint for contact updates
         endpoint = Endpoint.HostsContacts.with_params(self.name)
         try:
-            resp = MregClient().post(endpoint, emails=contacts)
+            resp = MregClient().post(endpoint, json={"emails": contacts})
         except PostError:
             # TODO: implement after mreg-cli parity
             # raise PostError(f"Failed to add contacts to host {self.name}.", e.response) from e
@@ -3337,7 +3346,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
 
         endpoint = Endpoint.HostsContacts.with_params(self.name)
         try:
-            resp = MregClient().delete(endpoint, emails=contacts)
+            resp = MregClient().delete(endpoint, json={"emails": contacts})
         except DeleteError as e:
             # TODO: implement after mreg-cli parity
             # raise DeleteError(f"Failed to remove contacts from host {self.name}.", e.response) from e
@@ -3352,7 +3361,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
             Host: Updated host after contact removal
         """
         # TODO: add try/except with error message
-        return self.patch(fields={"contacts": []})
+        return self.patch(data={"contacts": []})
 
     def add_ip(self, ip: IP_AddressT, mac: MacAddress | None = None) -> Host:
         """Add an IP address to the host.
@@ -3364,11 +3373,11 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         Returns:
             A new Host object fetched from the API with the updated IP address.
         """
-        params: QueryParams = {"ipaddress": str(ip), "host": str(self.id)}
+        data: JsonMapping = {"ipaddress": str(ip), "host": str(self.id)}
         if mac:
-            params["macaddress"] = mac
+            data["macaddress"] = mac
 
-        IPAddress.create(params=params)
+        IPAddress.create(data=data)
         return self.refetch()
 
     def has_ip(self, arg_ip: IP_AddressT) -> bool:
@@ -3969,7 +3978,7 @@ class HostGroup(FrozenModelWithTimestamps, WithName, WithHistory, APIMixin):
         Returns:
             A new HostGroup object fetched from the API with the updated description.
         """
-        return self.patch(fields={"description": description})
+        return self.patch(data={"description": description})
 
     def has_group(self, groupname: str) -> bool:
         """Check if the hostgroup has the given group.
@@ -3994,7 +4003,9 @@ class HostGroup(FrozenModelWithTimestamps, WithName, WithHistory, APIMixin):
         from mreg_api.client import MregClient  # noqa: PLC0415
 
         try:
-            MregClient().post(Endpoint.HostGroupsAddHostGroups.with_params(self.name), name=groupname)
+            MregClient().post(
+                Endpoint.HostGroupsAddHostGroups.with_params(self.name), json={"name": groupname}
+            )
         except PostError as e:
             # TODO: implement after mreg-cli parity
             # raise PostError(f"Failed to add group {groupname} to hostgroup {self.name}.", e.response)
@@ -4045,7 +4056,9 @@ class HostGroup(FrozenModelWithTimestamps, WithName, WithHistory, APIMixin):
         from mreg_api.client import MregClient  # noqa: PLC0415
 
         try:
-            MregClient().post(Endpoint.HostGroupsAddHosts.with_params(self.name), name=hostname)
+            MregClient().post(
+                Endpoint.HostGroupsAddHosts.with_params(self.name), json={"name": hostname}
+            )
         except PostError as e:
             # TODO: implement after mreg-cli parity
             # raise PostError(f"Failed to add host {hostname} to hostgroup {self.name}.", e.response)
@@ -4096,7 +4109,9 @@ class HostGroup(FrozenModelWithTimestamps, WithName, WithHistory, APIMixin):
         from mreg_api.client import MregClient  # noqa: PLC0415
 
         try:
-            MregClient().post(Endpoint.HostGroupsAddOwner.with_params(self.name), name=ownername)
+            MregClient().post(
+                Endpoint.HostGroupsAddOwner.with_params(self.name), json={"name": ownername}
+            )
         except PostError as e:
             # TODO: implement after mreg-cli parity
             # raise PostError(


### PR DESCRIPTION
Fixes #6 

## **kwargs removed

All CRUD methods have had `**kwargs` removed in favor of explicit `Json` and `JsonMapping` parameters. It is no longer ambiguous how JSON payload data is passed to `MregClient.request()`.

## Mapping types

This PR replaces all use of `Mapping[str, Any]` & `dict[str, Any]` in CRUD methods with `JsonMapping` (immutable) and `dict[str, Json]` (mutable).

Some cases still remain in other modules, but those are not directly related to the CRUD methods, and will be handled in separate PRs.