### PR TITLE
Add `APIMixin.endpoint_with_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `APIMixin.endpoint_with_id` property for getting the endpoint for the object with its ID, used for operations on the object itself (PATCH, DELETE, etc.). Used by default in `APIMixin.patch()` and `APIMixin.delete()`. Subclasses can override `endpoint_with_id` to provide custom endpoint resolution for these operations.
+
+### Removed
+
+- `Community.patch()`. Now uses `APIMixin.patch()`.
+- `Community.delete()`. Now uses `APIMixin.delete()`.
+
 ### Deprecated
 
 - `APIMixin.patch()` parameter `validate`. Has no effect and will be removed in a future release.

--- a/mreg_api/models/abstracts.py
+++ b/mreg_api/models/abstracts.py
@@ -68,8 +68,16 @@ class APIMixin(ABC):
     @classmethod
     @abstractmethod
     def endpoint(cls) -> Endpoint:
-        """Return the endpoint for the method."""
+        """Return the endpoint for the resource."""
         raise NotImplementedError("You must define an endpoint.")
+
+    @property
+    def endpoint_with_id(self) -> str:
+        """Return the endpoint for the object with its ID.
+
+        Used for operations on the object itself (PATCH, DELETE, etc.).
+        """
+        return self.endpoint().with_id(self.id_for_endpoint())
 
     @classmethod
     def get(cls, _id: int) -> Self | None:
@@ -481,7 +489,7 @@ class APIMixin(ABC):
         """
         from mreg_api.client import MregClient  # noqa: PLC0415
 
-        MregClient().patch(self.endpoint().with_id(self.id_for_endpoint()), json=data, params=params)
+        MregClient().patch(self.endpoint_with_id, json=data, params=params)
         new_object = self.refetch()
 
         return new_object
@@ -494,7 +502,7 @@ class APIMixin(ABC):
         """
         from mreg_api.client import MregClient  # noqa: PLC0415
 
-        response = MregClient().delete(self.endpoint().with_id(self.id_for_endpoint()))
+        response = MregClient().delete(self.endpoint_with_id)
 
         if response and response.is_success:
             return True

--- a/mreg_api/models/models.py
+++ b/mreg_api/models/models.py
@@ -2068,6 +2068,7 @@ class Community(FrozenModelWithTimestamps, APIMixin):
         return Endpoint.NetworkCommunity
 
     @property
+    @override
     def endpoint_with_id(self) -> str:
         """Return the endpoint with the community ID."""
         return self.endpoint().with_params(self.network_address, self.id)
@@ -2087,42 +2088,6 @@ class Community(FrozenModelWithTimestamps, APIMixin):
         from mreg_api.client import MregClient  # noqa: PLC0415
 
         return MregClient().get_typed(self.endpoint_with_id, self.__class__)
-
-    @override
-    def patch(
-        self,
-        data: JsonMapping,
-        *,
-        params: QueryParams | None = None,
-        validate: bool | None = None,  # noqa: ARG002
-    ) -> Self:
-        """Patch the community.
-
-        Args:
-            data: The data to patch.
-            params: Optional query parameters.
-            validate: Whether to validate the response. (Deprecated and ignored)
-
-        Returns:
-            The updated Community object.
-        """
-        from mreg_api.client import MregClient  # noqa: PLC0415
-
-        try:
-            MregClient().patch(self.endpoint_with_id, json=data, params=params)
-        except PatchError as e:
-            # TODO: implement after mreg-cli parity
-            # raise PatchError(f"Failed to patch community {self.name!r}", e.response) from e
-            raise e
-        new_object = self.refetch()
-        return new_object
-
-    def delete(self) -> bool:
-        """Delete the community."""
-        from mreg_api.client import MregClient  # noqa: PLC0415
-
-        resp = MregClient().delete(self.endpoint_with_id)
-        return resp.is_success if resp else False
 
     def get_hosts(self) -> list[Host]:
         """Get a list of hosts in the community.


### PR DESCRIPTION
Adds an interface for overriding the default endpoint resolution for modification/deletion of resources: `APIMixin.endpoint_with_id`. 

This lets us remove custom patch/delete methods and instead use `APIMixin.{patch,delete}` for everything by simply overriding `endpoint_with_id` where it is required.